### PR TITLE
Add in autogenerated passwords

### DIFF
--- a/nepho/aws/clidriver.py
+++ b/nepho/aws/clidriver.py
@@ -41,6 +41,11 @@ import json
 import collections
 import yaml
 import string
+import random
+
+char_set = string.ascii_uppercase + string.digits
+print ''.join(random.sample(char_set*6,6))
+
 from nepho.command import command
 #from nepho.aws import Deployment
 #from nepho.aws import Template
@@ -50,9 +55,16 @@ __DEPLOYMENTS_DIR__ = 'data/deployments'
 __PATTERNS_DIR__    = 'data/patterns'
 __DRIVERS_DIR__     = 'data/drivers'
 
+__PASSWORD_REPLACE_FLAG__ = 'NEPHO_CHANGEME_PASSWORD'
+
 LOG = logging.getLogger(__MODULE_NAME__)
 
-
+def gimme_random_password(lngth=32):
+    alpha_char_set =  string.ascii_uppercase + string.ascii_lowercase
+    char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits
+    first = random.sample(alpha_char_set,1)
+    rest = ''.join(random.sample(char_set*(lngth-1),lngth-1))
+    return" %s%s" % (first[0], rest)
 
 def setup_awscli_driver():
     emitter = HierarchicalEmitter()
@@ -168,6 +180,7 @@ def get_cf_template(pattern, context):
     return jinja_template.render(context)
 
 def parse_cf_json(str):
+    
     cf_dict =  json.loads(str, object_pairs_hook=collections.OrderedDict)
     return cf_dict
 
@@ -177,7 +190,9 @@ def get_cf_json(orderDict, pretty=False):
         outstr = json.dumps(orderDict, indent=2, separators=(',', ': '))
     else:
         outstr = json.dumps(orderDict)
-    return outstr
+        
+    password = gimme_random_password()   
+    return string.replace(outstr, __PASSWORD_REPLACE_FLAG__, password)
 
 def main(args_json=None):
     # Create an aws-cli driver
@@ -219,14 +234,13 @@ def main(args_json=None):
     paramsMap.pop('pattern')
 
     # Determine how to manage deployed instances
-    context = get_management_settings(paramsMap)
-
-
+    context = get_management_settings(paramsMap)  
 
     if args['subcmd'] == 'show-template':
         raw_template = get_cf_template(pattern, context)
         try:
             cf_dict = parse_cf_json(raw_template)
+            
             print get_cf_json(cf_dict, pretty=True)
         except ValueError:
             print raw_template

--- a/nepho/aws/clidriver.py
+++ b/nepho/aws/clidriver.py
@@ -43,9 +43,6 @@ import yaml
 import string
 import random
 
-char_set = string.ascii_uppercase + string.digits
-print ''.join(random.sample(char_set*6,6))
-
 from nepho.command import command
 #from nepho.aws import Deployment
 #from nepho.aws import Template

--- a/nepho/data/patterns/common/Parameters/RDS-Parameters.json
+++ b/nepho/data/patterns/common/Parameters/RDS-Parameters.json
@@ -39,7 +39,7 @@
     },
 
     "DBPassword": {
-      "Default": "admin",
+      "Default": "NEPHO_CHANGEME_PASSWORD",
       "NoEcho": "true",
       "Description" : "The Drupal database admin account password",
       "Type": "String",

--- a/nepho/data/patterns/multi-hosts/template.cf
+++ b/nepho/data/patterns/multi-hosts/template.cf
@@ -1,5 +1,6 @@
-{% import 'Resources/Host.json'   as host     with context %}
-{% import 'Outputs/Host-URL.json' as host_url with context %}
+{% import 'Parameters/Instance-Parameters.json' as inst_params %}
+{% import 'Resources/Host.json'                 as host     with context %}
+{% import 'Outputs/Host-URL.json'               as host_url with context %}
 
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
@@ -8,7 +9,12 @@
   
   "Parameters" : { 
   
-    {% include 'Parameters/General-Instance-Parameters.json' %}
+    {% include 'Parameters/General-Instance-Parameters.json' %},
+    {{ inst_params.inst_params(name="Server1") }},
+    {{ inst_params.inst_params(name="Server2") }},
+    {{ inst_params.inst_params(name="Server3") }},
+    {{ inst_params.inst_params(name="Server4") }},
+    {{ inst_params.inst_params(name="Server5") }}
     
   },
   

--- a/nepho/data/patterns/single-host/template.cf
+++ b/nepho/data/patterns/single-host/template.cf
@@ -1,4 +1,4 @@
-{% import 'Parameters/instance-Parameters.json' as inst_params %}
+{% import 'Parameters/Instance-Parameters.json' as inst_params %}
 {% import 'Resources/Host.json'   as host     with context %}
 {% import 'Outputs/Host-URL.json' as host_url with context %}
 

--- a/nepho/data/patterns/three-tier-ref-app/template.cf
+++ b/nepho/data/patterns/three-tier-ref-app/template.cf
@@ -6,7 +6,7 @@
 {% import 'Resources/Autoscale-Fleet.json' as fleet  with context %} 
 {% import 'Outputs/Host.json'            as host_out with context %}
 
-{# TODO: fully transition to macro and refectoring #}
+{# TODO: fully transition to macro and refactoring #}
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
 

--- a/nepho/data/patterns/vpc-three-tier-with-test-hosts/template.cf
+++ b/nepho/data/patterns/vpc-three-tier-with-test-hosts/template.cf
@@ -2,6 +2,7 @@
     Deploys a basic three tier VPC virtual datacenter, with test hosts on each tier.
 #}
 
+{% import 'Parameters/Instance-Parameters.json' as inst_params %}
 {% import 'Resources/Network-Tier.json' as networks with context %}
 {% import 'Resources/Host.json'         as host     with context %}
 {% import 'Outputs/Host.json'           as host_out with context %}
@@ -14,7 +15,9 @@
   "Parameters" : { 
   
     {% include 'Parameters/General-Instance-Parameters.json' %},
-    {% include 'Parameters/NAT-Instance-Parameters.json' %}   
+    {% include 'Parameters/NAT-Instance-Parameters.json' %},
+    {{ inst_params.inst_params(name="PrivateTierHost") }}
+    {{ inst_params.inst_params(name="DataTierHost") }}   
   },
 
   "Mappings" : {  

--- a/nepho/data/patterns/vpc-two-tier-ref/template.cf
+++ b/nepho/data/patterns/vpc-two-tier-ref/template.cf
@@ -17,8 +17,8 @@
   
     {% include 'Parameters/General-Instance-Parameters.json' %},
     {% include 'Parameters/NAT-Instance-Parameters.json' %}, 
-    {{ inst_params.inst_params(name="Public") }},  
-    {{ inst_params.inst_params(name="Private") }}
+    {{ inst_params.inst_params(name="Tier1") }},  
+    {{ inst_params.inst_params(name="Tier2") }}
     
   },
 
@@ -29,7 +29,6 @@
     {% include 'Mappings/Subnet-Mappings.json' %}    
     
   },
-
 
   "Resources" : {
 
@@ -50,30 +49,32 @@
     {{ s3.bucket(name='Shared') }},
     
 {# **** Public Tier Application instances **** #}
-{#
-    {{ elb.load_balancer(name='Public', subnet='PublicSubnet',  port=80) }},
+
+    {{ elb.load_balancer( name='Public', 
+                          subnet='PublicSubnet',  
+                          port=80                                      ) }},
     {{ fleet.fleet(      name='Tier1', 
                          subnet='PrivateSubnet', 
                          elb='PublicElasticLoadBalancer', 
                          bucket='SharedS3Bucket',
-                         ports=[80] ) }},  
-#}
+                         ports=[80]                                    ) }},  
 
-   {{ host.host( name='SingleServer', subnet='PrivateSubnet', bucket='SharedS3Bucket', ports=[80, 443]) }}
-   
 {# **** Private Tier Application instances **** #}
-{#
-    {{ elb.load_balancer( name='Private', subnet='PrivateSubnet',  port=80) }},
-    {{ fleet.fleet(       name='Private', subnet='PrivateSubnet', elb='PrivateElasticLoadBalancer', ports=[80]) }}
-#}
-    
+
+    {{ elb.load_balancer( name='Private', 
+                          subnet='PrivateSubnet',  
+                          port=80                                      ) }},
+    {{ fleet.fleet(       name='Tier2', 
+                          subnet='PrivateSubnet', 
+                          elb='PrivateElasticLoadBalancer', 
+                          ports=[80]                                   ) }}
+   
   },
  
   "Outputs" : {
 
-{#    {{ elb_out.elb(name='PublicElasticLoadBalancer') }}, #}
-{#    {{ s3_out.bucket(name='SharedS3Bucket') }}, #}
-
+    {{ elb_out.elb(name='PublicElasticLoadBalancer') }}, 
+    {{ s3_out.bucket(name='SharedS3Bucket') }},
     {% include 'Outputs/BastionHost.json' %},
     {% include 'Outputs/NAT.json' %}
 

--- a/nepho/data/patterns/vpc-two-tier-with-test-hosts/template.cf
+++ b/nepho/data/patterns/vpc-two-tier-with-test-hosts/template.cf
@@ -2,6 +2,7 @@
     Deploys a basic three tier VPC virtual datacenter, with test hosts on each tier.
 #}
 
+{% import 'Parameters/Instance-Parameters.json' as inst_params %}
 {% import 'Resources/Network-Tier.json' as networks with context %}
 {% import 'Resources/Host.json'         as host     with context %}
 {% import 'Outputs/Host.json'           as host_out with context %}
@@ -14,7 +15,9 @@
   "Parameters" : { 
   
     {% include 'Parameters/General-Instance-Parameters.json' %},
-    {% include 'Parameters/NAT-Instance-Parameters.json' %}   
+    {% include 'Parameters/NAT-Instance-Parameters.json' %},
+    {{ inst_params.inst_params(name="PrivateTierHost") }}
+    
   },
 
   "Mappings" : {  
@@ -38,6 +41,9 @@
 
     {% include 'Resources/NAT.json' %}, 
     {% include 'Resources/BastionHost.json' %},
+    
+{# **** Test host on private tier **** #}
+    
     {{ host.host( name='PrivateTierHost', ports=[22], subnet='PrivateSubnet') }}
         
   }, 


### PR DESCRIPTION
Any string NEPHO_CHANGEME_PASSWORD in the template will be replaced with an autogenerated password. Currently there's one per entire template, but since we only use this right now for RDS, not an issue.

In the future we'll want to replace each instance with a different password, and use the CF templating to handle refs within the template.

Passwords currently are 32 chars, start with a-zA-Z and the rest is a-zA-z0-9 (i.e. no digits in the first char.)
