### PR TITLE
inject JSON encoded string version of the YAML configs as NEPHO_CONFIGS

### DIFF
--- a/nepho/aws/clidriver.py
+++ b/nepho/aws/clidriver.py
@@ -246,14 +246,16 @@ def main(args_json=None):
 
 
     # Load settings from YAML deployment file
+    configMap = load_deployment_file(deployment_name, env_name)
     paramsMap = load_deployment_file(deployment_name, env_name)
-
 
     pattern =  paramsMap['pattern']
     paramsMap.pop('pattern')
 
     # Determine how to manage deployed instances
     context = get_management_settings(paramsMap)  
+    context['configs'] = json.dumps(configMap)
+
 
     if args['subcmd'] == 'show-template':
         raw_template = get_cf_template(pattern, context)

--- a/nepho/data/patterns/common/Resources/Autoscale-Fleet.json
+++ b/nepho/data/patterns/common/Resources/Autoscale-Fleet.json
@@ -292,8 +292,6 @@
           {% endif %}
           "export NEPHO_EXTERNAL_HOSTNAME=${NEPHO_PUBLIC_HOSTNAME}\n",
 		  
-	  "export NEPHO_INSTANCE_ROLE='",     { "Ref" : "{{ name }}InstanceRole" }, "'\n",
-
           {% if rds is not none  %}
 	  "export NEPHO_DATABASE_HOST='",     { "Fn::GetAtt": [ "{{ rds }}", "Endpoint.Address" ] }, "'\n",
 	  "export NEPHO_DATABASE_PORT='",     { "Fn::GetAtt": [ "{{ rds }}", "Endpoint.Port" ] }, "'\n",
@@ -326,6 +324,8 @@
           "export NEPHO_GIT_REPO_URL='",    { "Ref" : "ConfigMgmtGitRepo" }, "'\n",
           "export NEPHO_GIT_REPO_BRANCH='", { "Ref" : "ConfigMgmtGitRepoBranch" }, "'\n",
           {% endif %}
+
+          "export NEPHO_CONFIGS='{{ configs }}'\n",
                           
           {#  **** Include script snippets here ...  **** #}
       

--- a/nepho/data/patterns/common/Resources/Host.json
+++ b/nepho/data/patterns/common/Resources/Host.json
@@ -289,8 +289,6 @@
           {% endif %}
           "export NEPHO_EXTERNAL_HOSTNAME=${NEPHO_PUBLIC_HOSTNAME}\n",
 		  
-		  "export NEPHO_INSTANCE_ROLE='",     { "Ref" : "{{ name }}InstanceRole" }, "'\n",
-
 		  {% if rds is not none  %}
 		  "export NEPHO_DATABASE_HOST='",     { "Fn::GetAtt": [ "{{ rds }}", "Endpoint.Address" ] }, "'\n",
 		  "export NEPHO_DATABASE_PORT='",     { "Fn::GetAtt": [ "{{ rds }}", "Endpoint.Port" ] }, "'\n",
@@ -321,6 +319,8 @@
           "export NEPHO_GIT_REPO_URL='",    { "Ref" : "ConfigMgmtGitRepo" }, "'\n",
           "export NEPHO_GIT_REPO_BRANCH='", { "Ref" : "ConfigMgmtGitRepoBranch" }, "'\n",
           {% endif %}
+
+          "export NEPHO_CONFIGS='{{ configs }}'\n",
                           
           {#  **** Include script snippets here ...  **** #}
       


### PR DESCRIPTION
This should be failrly innocuous, but not sure if un-esacped quotes etc. may confuse the template.
