### PR TITLE
CloudWatch autoscaling based on ELB latency

### DIFF
--- a/nepho/data/deployments/mediawiki.yaml
+++ b/nepho/data/deployments/mediawiki.yaml
@@ -35,8 +35,12 @@ production:
   DBPassword: mediawiki
   DBUsername: mediawiki
   KeyName: mediawiki-poc
+  Tier1InstanceCount: 2
+  Tier2InstanceCount: 2
   Tier1InstanceRole: varnish
   Tier2InstanceRole: mediawiki
+  Tier1LatencyScaleUp: 0.3
+  Tier1LatencyScaleDown: 0.05
   AZ1: us-east-1a
   AZ2: us-east-1b  
   management: puppet
@@ -55,6 +59,8 @@ full-production:
   DBPassword: mediawiki
   DBUsername: mediawiki
   KeyName: mediawiki-poc
+  Tier1InstanceCount: 2
+  Tier2InstanceCount: 2
   Tier1InstanceRole: varnish
   Tier2InstanceRole: mediawiki
   AZ1: us-east-1a

--- a/nepho/data/patterns/common/Parameters/Instance-Parameters.json
+++ b/nepho/data/patterns/common/Parameters/Instance-Parameters.json
@@ -8,6 +8,8 @@
     - BackendtendInstanceType: EC2 instance type on public tier (default: m1.small).
     - FrontendInstanceCount: # of these instances (default: 2)
     - BackendInstanceCount: # of these instances (default: 2) 
+    - LatencyScaleUp: ELB latency above which to scale up the tier
+    - LatencyScaleDown: ELB latency above which to scale up the tier
     
 #} 
   
@@ -26,11 +28,23 @@
       "Type" : "Number",
       "Default" : "2"
     },
-    
+
     "{{ name }}InstanceRole" : {
       "Description" : "Role of this set of instances for use in config management bootstrapping.",
       "Type" : "String",
       "Default" : "unspecified"
-    }    
+    },
+
+    "{{ name }}LatencyScaleUp" : {
+          "Description" : "ELB latency above which to scale up the tier",
+          "Type" : "Number",
+          "Default" : "0.5"
+    },
+
+    "{{ name }}LatencyScaleDown" : {
+          "Description" : "ELB latency below which to scale down the tier",
+          "Type" : "Number",
+          "Default" : "0.1"
+    }
 
     {%- endmacro -%}

--- a/nepho/data/patterns/common/Resources/Autoscale-Fleet.json
+++ b/nepho/data/patterns/common/Resources/Autoscale-Fleet.json
@@ -15,7 +15,9 @@
                      bucket=None, 
                      public_bucket=None,
                      rds=None, 
-                     ports=[80]
+                     ports=[80],
+                     latencyup=0.3,
+                     latencydown=0.05
                    ) -%}
 
     {% if public_hostname is not none %}
@@ -142,7 +144,82 @@
         ]
       }      
     },     
-        
+
+
+    "{{ name }}ScaleUpAlarm" : {
+      "Type" : "AWS::CloudWatch::Alarm",
+      "Properties" : {
+        "AlarmDescription" : "{{ name }} alarm for scaling up",
+        "MetricName" : "Latency",
+        "Namespace" : "AWS/ELB",
+        "Statistic" : "Average",
+        "Period" : "60",
+        "EvaluationPeriods" : "2",
+        "Threshold" : { "Ref" : "{{ latencyup }}" },
+        "AlarmActions" : [
+          {
+            "Ref" : "{{ name }}ScaleUpPolicy"
+          }
+        ],
+        "Dimensions" : [
+          {
+            "Name" : "LoadBalancerName",
+            "Value" :{ "Ref" : "{{ elb }}" } 
+          }
+        ],
+        "ComparisonOperator" : "GreaterThanThreshold"
+      },
+      "DependsOn" : "{{ name }}ScaleUpPolicy"
+    },
+
+    "{{ name }}ScaleDownAlarm" : {
+      "Type" : "AWS::CloudWatch::Alarm",
+      "Properties" : {
+        "AlarmDescription" : "{{ name }} alarm for scaling down",
+        "MetricName" : "Latency",
+        "Namespace" : "AWS/ELB",
+        "Statistic" : "Average",
+        "Period" : "60",
+        "EvaluationPeriods" : "5",
+        "Threshold" : { "Ref" : "{{ latencydown }}" },
+        "AlarmActions" : [
+          {
+            "Ref" : "{{ name }}ScaleDownPolicy"
+          }
+        ],
+        "Dimensions" : [
+          {
+            "Name" : "LoadBalancerName",
+            "Value" :{ "Ref" : "{{ elb }}" }
+          }
+        ],
+        "ComparisonOperator" : "LessThanThreshold"
+      },
+      "DependsOn" : "{{ name }}ScaleDownPolicy"
+    },
+
+    "{{ name }}ScaleUpPolicy" : {
+      "Type" : "AWS::AutoScaling::ScalingPolicy",
+      "Properties" : {
+        "AdjustmentType" : "ChangeInCapacity",
+        "AutoScalingGroupName" : { "Ref" : "{{ name }}Fleet" },
+        "Cooldown" : "60",
+        "ScalingAdjustment" : "1"
+      },
+      "DependsOn" : "{{ name }}Fleet"
+    },
+
+    "{{ name }}ScaleDownPolicy" : {
+      "Type" : "AWS::AutoScaling::ScalingPolicy",
+      "Properties" : {
+        "AdjustmentType" : "ChangeInCapacity",
+        "AutoScalingGroupName" : { "Ref" : "{{ name }}Fleet" },
+        "Cooldown" : "120",
+        "ScalingAdjustment" : "-1"
+      },
+      "DependsOn" : "{{ name }}Fleet"
+    },
+
     "{{ name }}LaunchConfig"  : {
       "Type" : "AWS::AutoScaling::LaunchConfiguration",
       "Metadata" : {

--- a/nepho/data/patterns/full-monty/template.cf
+++ b/nepho/data/patterns/full-monty/template.cf
@@ -80,8 +80,8 @@
                          elb2='Tier2ElasticLoadBalancer',
                          public_hostname='{ "Fn::GetAtt" : [ "Tier1ElasticLoadBalancer", "DNSName" ]}',
                          rds='Tier3DBInstance',
-                         latencyup='Tier2LatencyScaleUp',
-                         latencydown='Tier2LatencyScaleDown',
+                         latencyup='Tier1LatencyScaleUp',
+                         latencydown='Tier1LatencyScaleDown',
                          ports=[80] ) }},  
 
 {# **** S3 **** #}

--- a/nepho/data/patterns/full-monty/template.cf
+++ b/nepho/data/patterns/full-monty/template.cf
@@ -1,14 +1,14 @@
 {% import 'Parameters/Instance-Parameters.json' as inst_params %}
-{% import 'Resources/Network-Tier.json'    as networks with context %}
-{% import 'Resources/S3-Bucket.json'       as s3 with context %}
-{% import 'Resources/RDS.json'             as rds with context %}
-{% import 'Resources/Host.json'            as host     with context %}
-{% import 'Resources/Load-Balancer.json'   as elb      with context %}  
-{% import 'Resources/Autoscale-Fleet.json' as fleet  with context %} 
-{% import 'Outputs/Host.json'              as host_out with context %}
-{% import 'Outputs/S3-Bucket.json'         as s3_out with context %}
-{% import 'Outputs/ELB-URL.json'           as elb_out with context %}
-{% import 'Outputs/RDS.json'               as rds_out with context %}
+{% import 'Resources/Network-Tier.json'     as networks with context %}
+{% import 'Resources/S3-Bucket.json'        as s3 with context %}
+{% import 'Resources/RDS.json'              as rds with context %}
+{% import 'Resources/Host.json'             as host     with context %}
+{% import 'Resources/Load-Balancer.json'    as elb      with context %}  
+{% import 'Resources/Autoscale-Fleet.json'  as fleet  with context %} 
+{% import 'Outputs/Host.json'               as host_out with context %}
+{% import 'Outputs/S3-Bucket.json'          as s3_out with context %}
+{% import 'Outputs/ELB-URL.json'            as elb_out with context %}
+{% import 'Outputs/RDS.json'                as rds_out with context %}
 {
 
   "AWSTemplateFormatVersion" : "2010-09-09",
@@ -80,6 +80,8 @@
                          elb2='Tier2ElasticLoadBalancer',
                          public_hostname='{ "Fn::GetAtt" : [ "Tier1ElasticLoadBalancer", "DNSName" ]}',
                          rds='Tier3DBInstance',
+                         latencyup='Tier2LatencyScaleUp',
+                         latencydown='Tier2LatencyScaleDown',
                          ports=[80] ) }},  
 
 {# **** S3 **** #}
@@ -100,6 +102,8 @@
                           bucket='Tier2SharedS3Bucket',
                           public_bucket=false,
                           rds='Tier3DBInstance',
+                          latencyup='Tier2LatencyScaleUp',
+                          latencydown='Tier2LatencyScaleDown',
                           ports=[8080]) }}
 
   },


### PR DESCRIPTION
By default, sets up CloudWatch alarms that scale each fleet in
response to the Latency metric on their respective ELBs.  Also includes
some defaults in mediawiki.yaml to prevent overzealous autoscaling from
knocking tiers down to a single instance.
