### PR TITLE
Fleet MinSize needs to be greater than 1

### DIFF
--- a/nepho/data/patterns/common/Resources/Autoscale-Fleet.json
+++ b/nepho/data/patterns/common/Resources/Autoscale-Fleet.json
@@ -116,7 +116,7 @@
         "AvailabilityZones" : [{ "Fn::GetAtt" : [ "{{ subnet }}", "AvailabilityZone" ] }],
         "VPCZoneIdentifier" : [{ "Ref" : "{{ subnet }}" }],
         "LaunchConfigurationName" : { "Ref" : "{{ name }}LaunchConfig"  },
-        "MinSize" : "1",
+        "MinSize" : { "Ref" : "{{ name }}InstanceCount" },
         "MaxSize" : "10",
         "DesiredCapacity" : { "Ref" : "{{ name }}InstanceCount" },
         "LoadBalancerNames" : [ { "Ref" : "{{ elb }}" } ],


### PR DESCRIPTION
Otherwise autoscaling will knock the fleet size down to MinSize when
Latency is low; DesiredCapacity only comes into play at Fleet creation
time, it seems.

This is a bugfix to #68; please do not merge it until you have taken a look at the deployment I'm kicking off:

```
"arn:aws:cloudformation:us-east-1:437323568624:stack/shuff2-mediawiki-production/aeccd7f0-2174-11e3-9381-500150b34c7c"
```

Please make sure that both tiers have at least two instances running.
