### PR TITLE
Adding support for sending email via SES

### DIFF
--- a/nepho/data/patterns/common/Parameters/SES-Parameters.json
+++ b/nepho/data/patterns/common/Parameters/SES-Parameters.json
@@ -1,0 +1,60 @@
+{#
+
+    A typical set of parameters relevant to Amazon SES.
+
+    Parameters:
+
+    - SESSMTP: enable SES SMTP sending?.
+    - SESEndpoint: hostname of the SES SMTP endpoint.
+    - SESPort: TCP port to use when sending SES mail (default "25")
+    - SESUsername: username of the SES SMTP account.
+    - SESPassword: password of the SES SMTP account.
+#}
+
+    "SESSMTP": {
+      "Default": "false",
+      "Description" : "Enable SES SMTP email?",
+      "Type": "String",
+      "AllowedValues" : [ "false", "true" ],
+      "ConstraintDescription" : "must be true or false."
+    },
+
+    "SESEndpoint": {
+      "Default": "email-smtp.us-east-1.amazonaws.com",
+      "Description" : "The SES SMTP endpoint",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "64",
+      "AllowedPattern" : "email-smtp.[-a-z0-9]*.amazonaws.com",
+      "ConstraintDescription" : "must look like a SES SMTP endpoint."
+    },
+
+    "SESPort": {
+      "Default": "25",
+      "Description" : "The SES SMTP port",
+      "Type": "String",
+      "AllowedValues" : [ "25", "465", "587" ],
+      "ConstraintDescription" : "must be 25, 465, or 587."
+    },
+
+    "SESUsername": {
+      "Default": "NEPHO_CHANGEME_USERNAME",
+      "NoEcho": "true",
+      "Description" : "The SES SMTP account username",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "24",
+      "AllowedPattern" : "[_A-Z0-9]*",
+      "ConstraintDescription" : "must contain only alphanumeric characters."
+    },
+
+    "SESPassword": {
+      "Default": "NEPHO_CHANGEME_PASSWORD",
+      "NoEcho": "true",
+      "Description" : "The SES SMTP account password",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "48",
+      "AllowedPattern" : ".*",
+      "ConstraintDescription" : "any characters."
+    }

--- a/nepho/data/patterns/common/Resources/Autoscale-Fleet.json
+++ b/nepho/data/patterns/common/Resources/Autoscale-Fleet.json
@@ -317,6 +317,11 @@
                           { "Ref": "DBName" }
                        ]]}, "'\n", 
 		  {% endif %}
+		  "export NEPHO_SES_SMTP='",          { "Ref" : "SESSMTP" }, "'\n",
+		  "export NEPHO_SES_SMTP_ENDPOINT='", { "Ref" : "SESEndpoint" }, "'\n",
+		  "export NEPHO_SES_SMTP_PORT='",     { "Ref" : "SESPort" }, "'\n",
+		  "export NEPHO_SES_SMTP_USER='",     { "Ref" : "SESUsername" }, "'\n",
+		  "export NEPHO_SES_SMTP_PASSWORD='", { "Ref" : "SESPassword" }, "'\n",
 		  
           "# pull & setup puppet modules and run manifest\n",
           {% if management !='script' and management != 'none' %}

--- a/nepho/data/patterns/common/Resources/Host.json
+++ b/nepho/data/patterns/common/Resources/Host.json
@@ -315,7 +315,12 @@
                           "/",
                           { "Ref": "DBName" }
                        ]]}, "'\n", 
-		  {% endif %}		  		 
+		  {% endif %}
+		  "export NEPHO_SES_SMTP='",          { "Ref" : "SESSMTP" }, "'\n",
+		  "export NEPHO_SES_SMTP_ENDPOINT='", { "Ref" : "SESEndpoint" }, "'\n",
+		  "export NEPHO_SES_SMTP_PORT='",     { "Ref" : "SESPort" }, "'\n",
+		  "export NEPHO_SES_SMTP_USER='",     { "Ref" : "SESUsername" }, "'\n",
+		  "export NEPHO_SES_SMTP_PASSWORD='", { "Ref" : "SESPassword" }, "'\n",
 		  {% if bucket is not none %}
 		  "export NEPHO_S3_BUCKET='", {"Ref" : "{{ bucket }}"}, "'\n",
 		  "export NEPHO_S3_BUCKET_URL='", { "Fn::Join" : [ "", [ "https://", { "Fn::GetAtt" : [ "{{ bucket }}", "DomainName" ]}]] }, "'\n",

--- a/nepho/data/patterns/full-monty/template.cf
+++ b/nepho/data/patterns/full-monty/template.cf
@@ -21,6 +21,7 @@
     {% include 'Parameters/General-Instance-Parameters.json' %},
     {% include 'Parameters/NAT-Instance-Parameters.json' %},
     {% include 'Parameters/RDS-Parameters.json' %},
+    {% include 'Parameters/SES-Parameters.json' %},
     {{ inst_params.inst_params(name="Tier1") }}, 
     {{ inst_params.inst_params(name="Tier2") }}
   },

--- a/nepho/data/patterns/single-host/template.cf
+++ b/nepho/data/patterns/single-host/template.cf
@@ -10,6 +10,7 @@
   "Parameters" : { 
   
     {% include 'Parameters/General-Instance-Parameters.json' %},
+    {% include 'Parameters/SES-Parameters.json' %},
     {{ inst_params.inst_params(name="SingleServer") }}
     
   },


### PR DESCRIPTION
Plumbing through some SES-specific parameters; now optionally deploy a
functional MTA on standalone and full-monty hosts.
