### PR TITLE
Bump awscli version to fix requests conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,13 @@ setup(
     install_requires = [
         'argparse>=1.2',
         'boto>=2.0',
-        'awscli>=0.13',
+        'awscli>=1.2.3',
         'Jinja2',
         'PyYAML',
         'cement>=2.0',
         'termcolor',
         'gitpython==0.3.2.RC1',
-        'requests==1.2.3',
+        'requests>=1.2.3',
         'ply==3.4'
     ],
 )


### PR DESCRIPTION
An older awscli was requiring requests==2.0.0; bumping the awscli version seems to have enabled nepho to install happily.
