### PR TITLE
Fix cloudlet installation

### DIFF
--- a/nepho/cli/cloudlet.py
+++ b/nepho/cli/cloudlet.py
@@ -127,9 +127,9 @@ class NephoCloudletController(base.NephoBaseController):
             exit(1)
 
         name = self.pargs.string[0]
-        #registry = cloudlet.cloudlet_registry(self)
+        registry = self.cloudletManager.get_registry()
 
-        if name in self.cloudletManager.get_registry():
+        if name in registry:
             url = registry[name]['source']
         else:
             if self.pargs.location is None:
@@ -138,20 +138,15 @@ class NephoCloudletController(base.NephoBaseController):
             else:
                 url = self.pargs.location
 
-        
         cloudlet_dirs = self.cloudletManager.all_cloudlet_dirs()
         selected_dir = common.select_list(self, cloudlet_dirs, False, "Select an install location:")
 
-        cloudlt = self.cloudletManager.new(name, selected_dir, url)
-#        cloudlt.clone(url)
-        
-#        cloudlet_dirs = self.config.get('nepho', 'cloudlet_dirs')
-#        selected_dir = common.select_list(self, cloudlet_dirs, False, "Select an install location:")
+        try:
+            cloudlt = self.cloudletManager.new(name, selected_dir, url)
+        except:
+            print colored("└──", "yellow"), name, "(", colored("error", "red"), "- install failed )"
 
-#        repo_path = path.join(selected_dir, name)
-
-        # The clone_cloudlet method will validate the location URL
-#        cloudlet.clone_cloudlet(self, url, repo_path)
+        return
 
     @controller.expose(help="Upgrade an installed Nepho cloudlet", aliases=["upgrade"])
     def update(self):

--- a/nepho/core/cloudlet.py
+++ b/nepho/core/cloudlet.py
@@ -245,7 +245,7 @@ class CloudletManager:
                 return yaml.load(yaml_file)
    
     def get_registry(self):
-        """Returns a dictionary woth registry values."""
+        """Returns a dictionary with registry values."""
         self.update_registry()
         cache_dir = self.config.get('cache_dir')
         registry_cache = path.join(cache_dir, "registry.yaml")


### PR DESCRIPTION
`nepho cloudlet install <foo>` works now, and traps exceptions in the
event that an install fails.

Fixes #102.
