### PR TITLE
Fixing nepho stack create

### DIFF
--- a/nepho/core/scenario.py
+++ b/nepho/core/scenario.py
@@ -44,6 +44,7 @@ class Scenario:
         """Return a generated template file for this blueprint and these params & configs."""
 
         template_string = self.resourceManager.render_template(self)
+        providr = self.get_provider()
         return providr.format_template(template_string)
 
     def get_pattern(self):


### PR DESCRIPTION
"providr" hadn't been defined in get_template()

Fixes #104.
