### PR TITLE
Cleaned up formatting in cli 

### DIFF
--- a/nepho/cli/base.py
+++ b/nepho/cli/base.py
@@ -63,9 +63,8 @@ class NephoBaseController(controller.CementBaseController):
                         makedirs(value)
 
         self.my_shared_obj = dict()
-        
+
         self.nepho_config = nepho.core.config.ConfigManager(self.config)
-        
 
     @controller.expose(hide=True)
     def default(self):

--- a/nepho/cli/cloudlet.py
+++ b/nepho/cli/cloudlet.py
@@ -35,17 +35,17 @@ class NephoCloudletController(base.NephoBaseController):
         super(NephoCloudletController, self)._setup(app)
         self.nepho_config = nepho.core.config.ConfigManager(self.config)
         self.cloudletManager = cloudlet.CloudletManager(self.nepho_config)
-        
+
     @controller.expose(help="List all installed cloudlets")
     def list(self):
-        
+
         cloudlets = self.cloudletManager.list()
-        
+
         dir = ""
         items = list()
 
         try:
-            for cloudlt in cloudlets: #sorted(all_cloudlets):
+            for cloudlt in cloudlets:  # sorted(all_cloudlets):
                 # Print directory if it changes
                 cloudlet_path = cloudlt.get_path()
                 if dir != path.dirname(cloudlet_path):
@@ -69,17 +69,17 @@ class NephoCloudletController(base.NephoBaseController):
             print colored("└──", "yellow"), colored("No cloudlets installed.", "blue")
 
         return
-    
+
         #cloudlet.list_all_cloudlets(self)
 
     @controller.expose(help="Describe an installed cloudlet")
     def describe(self):
-        
+
         cloudlt = self.cloudletManager.find(self.pargs.string[0])
-        
+
         wrapper = TextWrapper(width=80, subsequent_indent="              ")
         y = cloudlt.defn
-        
+
         print "-" * 80
         print "Name:         %s" % (y['name'])
         print "Version:      %s" % (y['version'])
@@ -96,19 +96,19 @@ class NephoCloudletController(base.NephoBaseController):
         # options, and experimented with throwing the registry into a local
         # sqlite database, but it seemed like overkill. Really this should be
         # calling a web service.
-        
+
         targetString = self.pargs.string[0]
         registry = self.cloudletManager.get_registry()
-        
+
         matchList = list()
         for cloudletRepo in registry.keys():
-            flattenedText =  "%s: %s" % (cloudletRepo, registry[cloudletRepo])
+            flattenedText = "%s: %s" % (cloudletRepo, registry[cloudletRepo])
             if targetString in flattenedText:
                 matchList.append(cloudletRepo)
-        
+
         if len(matchList) == 0:
             print "No matches found."
-        else:                
+        else:
             for cloudletRepo in matchList:
                 cloudletDict = registry[cloudletRepo]
 
@@ -120,11 +120,10 @@ class NephoCloudletController(base.NephoBaseController):
                 print "License:      %s" % (cloudletDict['license'])
                 print wrapper.fill("Summary:      %s" % (cloudletDict['summary']))
                 print wrapper.fill("Description:  %s" % (cloudletDict['description']))
-                print "-" * 80 
-        
+                print "-" * 80
+
         #print "Unimplemented action. (input: %s)" % self.pargs.string
 
-    
     @controller.expose(help="Install a Nepho cloudlet from the Nepho Cloudlet Registry or from an external Git repository")
     def install(self):
         if self.pargs.string == []:
@@ -155,12 +154,12 @@ class NephoCloudletController(base.NephoBaseController):
 
     @controller.expose(help="Upgrade an installed Nepho cloudlet", aliases=["upgrade"])
     def update(self):
-        
+
         cloudlts = self.cloudletManager.find(self.pargs.string[0])
         if cloudlts is None:
             print "Cloudlet is not installed."
             exit(1)
-        
+
         if not isinstance(cloudlts, list):
             cloudlts = [cloudlts]
         for cloudlt in cloudlts:
@@ -170,7 +169,7 @@ class NephoCloudletController(base.NephoBaseController):
     def uninstall(self):
         name = self.pargs.string[0]
         cloudlt = self.cloudletManager.find(name)
-        
+
         if cloudlt is None:
             print "No cloudlet named %s was found.\n" % (name)
             exit(1)
@@ -185,21 +184,20 @@ class NephoCloudletController(base.NephoBaseController):
         cloudlt.uninstall()
 
     @controller.expose(help="Update the local cloudlet registry.", aliases=["registry-update", "update-registry"])
-    def registry_update(self):      
+    def registry_update(self):
         self.cloudletManager.clear_registry()
         self.cloudletManager.update_registry()
 
-        
     def update_registry(self):
         cloudlts = self.cloudletManager.find(self.pargs.string[0])
         if cloudlts is None:
             print "Cloudlet is not installed."
             exit(1)
-        
+
         if not isinstance(cloudlts, list):
             cloudlts = [cloudlts]
         for cloudlt in cloudlts:
-            cloudlt.update()        
+            cloudlt.update()
 #        try:
 #            name = self.pargs.string[0]
 #            possible_paths = common.find_cloudlet(self, name, True)

--- a/nepho/cli/config.py
+++ b/nepho/cli/config.py
@@ -11,12 +11,13 @@ from cement.core import controller
 from nepho.cli import base
 from nepho.core import common, cloudlet, blueprint, config
 
+
 class NephoConfigController(base.NephoBaseController):
     class Meta:
         label = 'config'
         stacked_on = None
         description = 'list, view and modify config settings'
-        usage = "nepho config <action> [key] [value]" 
+        usage = "nepho config <action> [key] [value]"
         arguments = [
             (['key'], dict(help=argparse.SUPPRESS, nargs='?')),
             (['value'], dict(help=argparse.SUPPRESS, nargs='?')),
@@ -25,21 +26,21 @@ class NephoConfigController(base.NephoBaseController):
     def _setup(self, app):
         super(base.NephoBaseController, self)._setup(app)
         self.nepho_config = nepho.core.config.ConfigManager(self.config)
-        
+
     @controller.expose(help='List all config values.')
     def list(self):
 
         # Prepare to wrap description text
         wrapper = TextWrapper(width=80, initial_indent="        ", subsequent_indent="        ")
         print "-" * 80
-                
-        keys = sorted(self.nepho_config.keys( ) )
+
+        keys = sorted(self.nepho_config.keys())
         for k in keys:
             v = self.nepho_config.get(k)
             if isinstance(v, basestring):
-                print colored(" %s: " % (k), "yellow" ), colored( "\"%s\"" % (v), "blue" )
+                print colored(" %s: " % (k), "yellow"), colored("\"%s\"" % (v), "blue")
             else:
-                print colored(" %s: " % (k), "yellow" ), colored( "%s" % (v), "blue"  )            
+                print colored(" %s: " % (k), "yellow"), colored("%s" % (v), "blue")
         print "-" * 80
 
     @controller.expose(help='Get a config value')
@@ -48,21 +49,17 @@ class NephoConfigController(base.NephoBaseController):
             print "Usage: nepho config get <key>"
             exit(1)
         print self.nepho_config.get(self.pargs.key)
-            
-    
+
     @controller.expose(help='Set a config value', aliases=["add"])
     def set(self):
         if self.pargs.key is None or self.pargs.value is None:
             print "Usage: nepho config set <key> <value>"
             exit(1)
-        self.nepho_config.set(self.pargs.key, self.pargs.value) 
-            
+        self.nepho_config.set(self.pargs.key, self.pargs.value)
+
     @controller.expose(help='Unset a config value', aliases=["delete", "remove"])
     def unset(self):
         if self.pargs.key is None:
             print "Usage: nepho config unset <key> <value>"
             exit(1)
-        self.nepho_config.unset(self.pargs.key) 
-            
-    
-        
+        self.nepho_config.unset(self.pargs.key)

--- a/nepho/cli/parameter.py
+++ b/nepho/cli/parameter.py
@@ -11,15 +11,16 @@ from cement.core import controller
 from nepho.cli import base
 from nepho.core import common, cloudlet, blueprint, config
 
+
 class NephoParameterController(base.NephoBaseController):
     class Meta:
         label = 'parameter'
         stacked_on = None
         description = 'list, view and modify parameter settings'
-        usage = "nepho parameter <action> [cloudlet] [blueprint] [key] [value]" 
+        usage = "nepho parameter <action> [cloudlet] [blueprint] [key] [value]"
         arguments = [
             (['--cloudlet'], dict(dest='cloudlet', help=argparse.SUPPRESS, nargs='?')),
-            (['--blueprint'], dict(dest='blueprint',help=argparse.SUPPRESS, nargs='?')),
+            (['--blueprint'], dict(dest='blueprint', help=argparse.SUPPRESS, nargs='?')),
             (['key'], dict(help=argparse.SUPPRESS, nargs='?')),
             (['value'], dict(help=argparse.SUPPRESS, nargs='?')),
         ]
@@ -27,21 +28,21 @@ class NephoParameterController(base.NephoBaseController):
     def _setup(self, app):
         super(base.NephoBaseController, self)._setup(app)
         self.nepho_config = nepho.core.config.ConfigManager(self.config)
-        
+
     @controller.expose(help='List parameters.')
     def list(self):
 
         # Prepare to wrap description text
         wrapper = TextWrapper(width=80, initial_indent="        ", subsequent_indent="        ")
         print "-" * 80
-                
-        keys = sorted(self.nepho_config.keys("parameters") )
+
+        keys = sorted(self.nepho_config.keys("parameters"))
         for k in keys:
             v = self.nepho_config.get(k, "parameters")
             if isinstance(v, basestring):
-                print colored(" %s: " % (k), "yellow" ), colored( "\"%s\"" % (v), "blue" )
+                print colored(" %s: " % (k), "yellow"), colored("\"%s\"" % (v), "blue")
             else:
-                print colored(" %s: " % (k), "yellow" ), colored( "%s" % (v), "blue"  )            
+                print colored(" %s: " % (k), "yellow"), colored("%s" % (v), "blue")
         print "-" * 80
 
     @controller.expose(help='Get a parameter value')
@@ -49,27 +50,23 @@ class NephoParameterController(base.NephoBaseController):
         if self.pargs.key is None:
             print "Usage: nepho parameter get <key>"
             exit(1)
-        domain="parameters"    
+        domain = "parameters"
         print self.nepho_config.get(self.pargs.key, domain)
-            
-    
+
     @controller.expose(help='Set a parameter value', aliases=["add"])
     def set(self):
         if self.pargs.key is None or self.pargs.value is None:
             print "Usage: nepho parameter set <key>"
             exit(1)
-        domain="parameters"
-        
-        self.nepho_config.set(self.pargs.key, self.pargs.value, domain) 
-            
-   
+        domain = "parameters"
+
+        self.nepho_config.set(self.pargs.key, self.pargs.value, domain)
+
     @controller.expose(help='unset a parameter value', aliases=["remove", "delete"])
     def unset(self):
         if self.pargs.key is None:
             print "Usage: nepho parameter unset <key>"
             exit(1)
-        domain="parameters"
-        
-        self.nepho_config.unset(self.pargs.key, domain) 
-            
-        
+        domain = "parameters"
+
+        self.nepho_config.unset(self.pargs.key, domain)

--- a/nepho/cli/stack.py
+++ b/nepho/cli/stack.py
@@ -27,12 +27,12 @@ class NephoStackController(base.NephoBaseController):
             (['--save', '-s'], dict(help=argparse.SUPPRESS, action='store_true')),
             (['--params', '-p'], dict(help=argparse.SUPPRESS, nargs='*', action='append')),
         ]
-        
+
     def _setup(self, app):
         super(base.NephoBaseController, self)._setup(app)
         self.nepho_config = nepho.core.config.ConfigManager(self.config)
         self.cloudletManager = cloudlet.CloudletManager(self.nepho_config)
-        
+
     @controller.expose(help='Show the context for a stack from a blueprint and configs', aliases=['show-context'])
     def show_context(self):
         if self.pargs.cloudlet is None or self.pargs.blueprint is None:
@@ -53,18 +53,15 @@ class NephoStackController(base.NephoBaseController):
                   nepho stack show-context my-app development --params AwsAvailZone1=us-east-1a
                   nepho stack show-context my-app development -s -p Foo=True -p Bar=False""")
             exit(1)
-        
+
         scene = self._assemble_scenario()
         ctxt = scene.get_context()
 
-        
         #Use JSON lib to pretty print a sorted version of this ...
         print colored("Context:", "yellow")
         print colored("-" * 80, "yellow")
         print yaml.dump(ctxt)
 #        print json.dumps(json.loads(json.dumps(ctxt), object_pairs_hook=collections.OrderedDict), indent=2, separators=(',', ': '))
-
-        
 
     @controller.expose(help='Show the template output for a stack from a blueprint', aliases=['show-template'])
     def show_template(self):
@@ -87,10 +84,9 @@ class NephoStackController(base.NephoBaseController):
                   nepho stack show-template my-app development -s -p Foo=True -p Bar=False""")
             exit(1)
 
-        scene = self._assemble_scenario()       
+        scene = self._assemble_scenario()
         print scene.get_template()
 
-                        
     @controller.expose(help='Create a stack from a blueprint', aliases=['deploy'])
     def create(self):
         if self.pargs.cloudlet is None or self.pargs.blueprint is None:
@@ -114,136 +110,130 @@ class NephoStackController(base.NephoBaseController):
 
         scene = self._assemble_scenario()
         scene.provider.deploy()
-        
 
     @controller.expose(help='Check on the status of a stack.')
     def status(self):
         if self.pargs.cloudlet is None or self.pargs.blueprint is None:
             print dedent("""\
-                Usage: nepho stack status <cloudlet> <blueprint> 
+                Usage: nepho stack status <cloudlet> <blueprint>
 
                 Examples:
-                  nepho stack status my-app development 
+                  nepho stack status my-app development
                 """)
             exit(1)
- 
+
         scene = self._assemble_scenario()
-        
+
         status = scene.provider.status()
         print status
         exit(0)
-        
+
         #
         # Report system status
-        # 
+        #
         header_string = "%s/%s" % (self.pargs.cloudlet, self.pargs.blueprint)
         print colored(header_string, "yellow")
-        print colored( "-" * len(header_string), "yellow")
-        rep_string = "The stack is currently %s." % ( status['default'] )
+        print colored("-" * len(header_string), "yellow")
+        rep_string = "The stack is currently %s." % (status['default'])
         color = "blue"
-        if  status['default'] == "running":
+        if status['default'] == "running":
             color = 'green'
-        if  status['default'] == "aborted":
+        if status['default'] == "aborted":
             color = 'red'
         print colored(rep_string, color)
-        
+
     @controller.expose(help='Gain access to the stack')
     def access(self):
         if self.pargs.cloudlet is None or self.pargs.blueprint is None:
             print dedent("""\
-                Usage: nepho stack access <cloudlet> <blueprint> 
+                Usage: nepho stack access <cloudlet> <blueprint>
 
                 Examples:
-                  nepho stack access my-app development 
+                  nepho stack access my-app development
                 """)
             exit(1)
-        
+
         scene = self._assemble_scenario()
 
         scene.provider.access()
-        
+
     @controller.expose(help='Destroy a stack from a blueprint', aliases=['delete'])
     def destroy(self):
         if self.pargs.cloudlet is None or self.pargs.blueprint is None:
             print dedent("""\
-                Usage: nepho stack destroy <cloudlet> <blueprint> 
+                Usage: nepho stack destroy <cloudlet> <blueprint>
 
                 Examples:
-                  nepho stack destroy my-app development 
+                  nepho stack destroy my-app development
                 """)
             exit(1)
-        
+
         scene = self._assemble_scenario()
-        
+
         scene.provider.destroy()
-        
-         
+
     @controller.expose(help='List deployed stacks')
     def list(self):
         if self.pargs.cloudlet is None or self.pargs.blueprint is None:
             print dedent("""
-                Usage: nepho stack list <cloudlet> <blueprint> 
+                Usage: nepho stack list <cloudlet> <blueprint>
 
                 Examples:
                   nepho stack list
-                  nepho stack list my-app 
+                  nepho stack list my-app
                   nepho stack list my-app development """)
             exit(1)
-            
+
         try:
-            cloudlt = self.cloudletManager.find(self.pargs.cloudlet) 
+            cloudlt = self.cloudletManager.find(self.pargs.cloudlet)
             y = cloudlt.defn
         except IOError:
             print colored("└──", "yellow"), cloudlt.name, "(", colored("error", "red"), "- missing or malformed cloudlet.yaml )"
             exit(1)
         else:
             print colored("└──", "yellow"), cloudlt.name, "(", colored("v%s", "blue") % (y['version']), ")"
-                    
-        bprint = cloudlt.blueprint(self.pargs.blueprint)   
-        
+
+        bprint = cloudlt.blueprint(self.pargs.blueprint)
+
         # Create an appropriate provider, and set the target pattern.
         provider_name = bprint.provider_name()
         providr = provider.ProviderFactory(provider_name, self.config)
         providr.pattern(bprint.pattern())
-        
-        
+
         print "Partially implemented action. (input: %s)" % self.pargs.params
 
     def _parse_params(self):
         """Helper method to extract params from command line into a dict."""
-        params=dict()
+        params = dict()
         if self.pargs.params is not None:
             paramList = self.pargs.params
             for item in paramList[0]:
-                (k,v) = item.split("=")
-                params[k]=v
+                (k, v) = item.split("=")
+                params[k] = v
         return params
-        
+
     def _load_blueprint(self):
         """Helper method to load blueprint & pattern from args."""
         try:
-            cloudlt = self.cloudletManager.find(self.pargs.cloudlet) 
+            cloudlt = self.cloudletManager.find(self.pargs.cloudlet)
             y = cloudlt.defn
         except Exception:
             print colored("Error loading cloudlet %s" % (self.pargs.cloudlet), "red")
             exit(1)
-                   
-        bprint = cloudlt.blueprint(self.pargs.blueprint)   
-        
+
+        bprint = cloudlt.blueprint(self.pargs.blueprint)
+
         if bprint is None:
             print "Cannot find blueprint %s in cloudlet %s." % (self.pargs.blueprint, self.pargs.cloudlet)
-            exit (1)
-                
+            exit(1)
+
         return bprint
-    
-    def _assemble_scenario(self):     
+
+    def _assemble_scenario(self):
         """Helper method to create a suitable scenario from the command line options."""
 
-        params = self._parse_params()               
-        bprint = self._load_blueprint()        
+        params = self._parse_params()
+        bprint = self._load_blueprint()
         scene = scenario.Scenario(self.nepho_config, bprint, params)
-        
-        return scene
 
-        
-        
+        return scene


### PR DESCRIPTION
I cleaned up all the whitespace and formatting issues in cli but I left in a couple other issues that we should clean up.  a couple of variables that get called assigned but never used.  Is there any reason **not** to clean these up in the future?

cli/cloudlet.py:149:13: F841 local variable 'cloudlt' is assigned to but never used
cli/config.py:34:9: F841 local variable 'wrapper' is assigned to but never used
cli/parameter.py:36:9: F841 local variable 'wrapper' is assigned to but never used
cli/stack.py:219:13: F841 local variable 'y' is assigned to but never used
