### PR TITLE
Feature/integrate scope in CLI

### DIFF
--- a/bin/nepho
+++ b/bin/nepho
@@ -14,7 +14,7 @@ def main():
     handler.register(cli.stack.NephoStackController)
     handler.register(cli.config.NephoConfigController)
     handler.register(cli.parameter.NephoParameterController)
-    #handler.register(cli.scope.NephoScopeController)
+    handler.register(cli.scope.NephoScopeController)
 
     try:
         app.setup()

--- a/nepho/cli/blueprint.py
+++ b/nepho/cli/blueprint.py
@@ -30,9 +30,9 @@ class NephoBlueprintController(base.NephoBaseController):
 
     @controller.expose(help='List all blueprints in a cloudlet')
     def list(self):
-        
+
         cloudlet_name = self._read_cloudlet()
-        
+
         if cloudlet_name is None:
             print "Usage: nepho blueprint list [cloudlet]"
             exit(1)
@@ -64,9 +64,9 @@ class NephoBlueprintController(base.NephoBaseController):
 
     @controller.expose(help='Describe a blueprint')
     def describe(self):
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
-        
+
         print blueprint_name
         if cloudlet_name is None or blueprint_name is None:
             print "Usage: nepho blueprint describe <cloudlet> <blueprint>"
@@ -103,24 +103,20 @@ class NephoBlueprintController(base.NephoBaseController):
 
     def _read_cloudlet(self):
         """Determine the cloudlet name to operate on."""
-        
+
         cloudlet_name = self.nepho_config.get("scope_cloudlet")
         if self.pargs.cloudlet is not None:
             cloudlet_name =  self.pargs.cloudlet
-        
-#        if cloudlet_name is None:
-#            print colored("No cloudlet specified. ", "red")
-#            exit(1)
-            
+
         return cloudlet_name
     
     def _read_cloudlet_and_blueprint(self):
         """Determine the cloudlet and blueprint names to operate on."""
-        
+
         cloudlet_name = self._read_cloudlet()
         blueprint_name = self.nepho_config.get("scope_blueprint")
         if self.pargs.blueprint is not None:
             blueprint_name = self.pargs.blueprint
-            
+    
         return (cloudlet_name, blueprint_name)
     

--- a/nepho/cli/cloudlet.py
+++ b/nepho/cli/cloudlet.py
@@ -75,7 +75,12 @@ class NephoCloudletController(base.NephoBaseController):
     @controller.expose(help="Describe an installed cloudlet")
     def describe(self):
 
-        cloudlt = self.cloudletManager.find(self.pargs.string[0])
+        cloudlet_name = self._read_cloudlet()
+            
+        cloudlt = self.cloudletManager.find(cloudlet_name)
+        if cloudlt is None:
+            print colored("No cloudlet named \"%s\" found." % (cloudlet_name), "red")
+            exit(1)        
 
         wrapper = TextWrapper(width=80, subsequent_indent="              ")
         y = cloudlt.defn
@@ -130,7 +135,7 @@ class NephoCloudletController(base.NephoBaseController):
             print "Usage: nepho cloudlet install <cloudlet> [--location <location>]"
             exit(1)
 
-        name = self.pargs.string[0]
+        name = self._read_cloudlet()
         registry = self.cloudletManager.get_registry()
 
         if name in registry:
@@ -155,7 +160,9 @@ class NephoCloudletController(base.NephoBaseController):
     @controller.expose(help="Upgrade an installed Nepho cloudlet", aliases=["upgrade"])
     def update(self):
 
-        cloudlts = self.cloudletManager.find(self.pargs.string[0])
+        name = self._read_cloudlet()
+        
+        cloudlts = self.cloudletManager.find(name)
         if cloudlts is None:
             print "Cloudlet is not installed."
             exit(1)
@@ -167,7 +174,7 @@ class NephoCloudletController(base.NephoBaseController):
 
     @controller.expose(help="Uninstall a Nepho cloudlet")
     def uninstall(self):
-        name = self.pargs.string[0]
+        name = self._read_cloudlet()
         cloudlt = self.cloudletManager.find(name)
 
         if cloudlt is None:
@@ -198,6 +205,20 @@ class NephoCloudletController(base.NephoBaseController):
             cloudlts = [cloudlts]
         for cloudlt in cloudlts:
             cloudlt.update()
+            
+    def _read_cloudlet(self):
+        """Determine the cloudlet name to operate on."""
+        
+        cloudlet_name = self.nepho_config.get("scope_cloudlet")
+        if len(self.pargs.string) > 0 and self.pargs.string[0] is not None:
+            cloudlet_name = self.pargs.string[0]
+        
+        if cloudlet_name is None:
+            print colored("No cloudlet specified. ", "red")
+            exit(1)
+            
+        return cloudlet_name
+    
 #        try:
 #            name = self.pargs.string[0]
 #            possible_paths = common.find_cloudlet(self, name, True)

--- a/nepho/cli/stack.py
+++ b/nepho/cli/stack.py
@@ -35,9 +35,9 @@ class NephoStackController(base.NephoBaseController):
 
     @controller.expose(help='Show the context for a stack from a blueprint and configs', aliases=['show-context'])
     def show_context(self):
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
-        
+
         if cloudlet_name is None or blueprint_name is None:
             print dedent("""\
                 Usage: nepho stack show-context <cloudlet> <blueprint> [--save] [--params Key1=Val1]
@@ -68,7 +68,7 @@ class NephoStackController(base.NephoBaseController):
 
     @controller.expose(help='Show the template output for a stack from a blueprint', aliases=['show-template'])
     def show_template(self):
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
         if cloudlet_name is None or blueprint_name is None:
             print dedent("""\
@@ -94,7 +94,7 @@ class NephoStackController(base.NephoBaseController):
 
     @controller.expose(help='Create a stack from a blueprint', aliases=['deploy'])
     def create(self):
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
         if cloudlet_name is None or blueprint_name is None:
             print dedent("""\
@@ -120,7 +120,7 @@ class NephoStackController(base.NephoBaseController):
 
     @controller.expose(help='Check on the status of a stack.')
     def status(self):
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
         if cloudlet_name is None or blueprint_name is None:
             print dedent("""\
@@ -153,7 +153,7 @@ class NephoStackController(base.NephoBaseController):
 
     @controller.expose(help='Gain access to the stack')
     def access(self):
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
         if cloudlet_name is None or blueprint_name is None:
             print dedent("""\
@@ -170,7 +170,7 @@ class NephoStackController(base.NephoBaseController):
 
     @controller.expose(help='Destroy a stack from a blueprint', aliases=['delete'])
     def destroy(self):
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
         if cloudlet_name is None or blueprint_name is None:
             print dedent("""\
@@ -187,7 +187,7 @@ class NephoStackController(base.NephoBaseController):
 
     @controller.expose(help='List deployed stacks')
     def list(self):
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
         if cloudlet_name is None or blueprint_name is None:
             print dedent("""
@@ -219,25 +219,21 @@ class NephoStackController(base.NephoBaseController):
 
     def _read_cloudlet(self):
         """Determine the cloudlet name to operate on."""
-        
+
         cloudlet_name = self.nepho_config.get("scope_cloudlet")
         if self.pargs.cloudlet is not None:
             cloudlet_name =  self.pargs.cloudlet
-        
-#        if cloudlet_name is None:
-#            print colored("No cloudlet specified. ", "red")
-#            exit(1)
-            
+
         return cloudlet_name
-    
+
     def _read_cloudlet_and_blueprint(self):
         """Determine the cloudlet and blueprint names to operate on."""
-        
+
         cloudlet_name = self._read_cloudlet()
         blueprint_name = self.nepho_config.get("scope_blueprint")
         if self.pargs.blueprint is not None:
             blueprint_name = self.pargs.blueprint
-            
+
         return (cloudlet_name, blueprint_name)
     
     def _parse_params(self):
@@ -252,7 +248,7 @@ class NephoStackController(base.NephoBaseController):
 
     def _load_blueprint(self):
         """Helper method to load blueprint & pattern from args."""
-        
+
         (cloudlet_name, blueprint_name) = self._read_cloudlet_and_blueprint()
         try:
             cloudlt = self.cloudletManager.find(cloudlet_name)

--- a/nepho/core/resource.py
+++ b/nepho/core/resource.py
@@ -75,9 +75,6 @@ class ResourceManager:
         pattern = scenario.get_pattern()
         context = scenario.get_context()
 
-        print "provider is"
-        print providr
-
         template_file_abs = pattern.get_template_file()
         template_dir = path.dirname(template_file_abs)
         template_common_dir = path.join(


### PR DESCRIPTION
This completes the work of integrating scope into the CLI (I'm pretty sure ...) by first checking the configs for the proper setting, then reading from the command line.

Now enable things like:

```
nepho stack create
nepho stack statu
nepho stack destroy
```
