### PR TITLE
Feature/vagrant pretty print

### DIFF
--- a/nepho/cli/stack.py
+++ b/nepho/cli/stack.py
@@ -134,7 +134,7 @@ class NephoStackController(base.NephoBaseController):
         scene = self._assemble_scenario()
 
         status = scene.provider.status()
-        print status
+	print json.dumps(status, sort_keys=True,indent=4, separators=(',', ': '))
         exit(0)
 
         #

--- a/nepho/cli/stack.py
+++ b/nepho/cli/stack.py
@@ -134,7 +134,7 @@ class NephoStackController(base.NephoBaseController):
         scene = self._assemble_scenario()
 
         status = scene.provider.status()
-	print json.dumps(status, sort_keys=True,indent=4, separators=(',', ': '))
+        print json.dumps(status, sort_keys=True, indent=4, separators=(',', ': '))
         exit(0)
 
         #


### PR DESCRIPTION
Question but we could pull it in if we want, what would folks think about doing something like this for the output of status?  I thought it might make things a little more readable .. there some sample output:

``` Json
{
    "conf": {
        "Host": "default",
        "HostName": "127.0.0.1",
        "IdentitiesOnly": "yes",
        "IdentityFile": "/Users/alaric/.vagrant.d/insecure_private_key",
        "LogLevel": "FATAL",
        "PasswordAuthentication": "no",
        "Port": "2222",
        "StrictHostKeyChecking": "no",
        "User": "vagrant",
        "UserKnownHostsFile": "/dev/null"
    },
    "default": "running",
    "hostname": "127.0.0.1",
    "keyfile": "/Users/alaric/.vagrant.d/insecure_private_key",
    "port": "2222",
    "remote_user": "vagrant"
}
```
