### PR TITLE
Python 2.6 added to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '2.6'
 install:
 - sudo wget -nv http://files.vagrantup.com/packages/7e400d00a3c5a0fdf2809c8b5001a035415a607b/vagrant_1.2.2_x86_64.deb
 - sudo dpkg -i vagrant_1.2.2_x86_64.deb


### PR DESCRIPTION
Adding a test to see if nepho runs on python 2.6, so far seems to! 
