### PR TITLE
Capture dependency on setuptools-git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'python-vagrant==0.4.0'
     ],
     setup_requires = [
+        'setuptools_git>=1.0',
         'flake8>=2.1.0',
         'nose>=1.3.0',
         'coverage>=3.7',


### PR DESCRIPTION
This can go away once cement 2.1 is released.  For now it just makes me feel better, and kinda sorta fixes #185 
