### PR TITLE
Make it easier to handle more complicated AWS JSON templates

### DIFF
--- a/nepho/cli/stack.py
+++ b/nepho/cli/stack.py
@@ -80,7 +80,6 @@ class NephoStackController(base.NephoBaseController):
 
         print self._assemble_scenario().template
 
-
     @controller.expose(help='Create a stack from a blueprint', aliases=['deploy', 'up'])
     def create(self):
         if self.app.cloudlet_name is None or self.app.blueprint_name is None:

--- a/nepho/cli/stack.py
+++ b/nepho/cli/stack.py
@@ -67,10 +67,10 @@ class NephoStackController(base.NephoBaseController):
         output  = "-" * 80 + "\n"
         output += s.provider.validate_template(s.template)
         output += "\n" + "-" * 80 + "\n"
-        output += s.template
+        output += s.provider.format_template(s.template)
         pager(output)
 
-    @controller.expose(help='Display the raw template output for a stack from a blueprint')
+    @controller.expose(help='Display the raw template for a stack from a blueprint')
     def show_template(self):
         if self.app.cloudlet_name is None or self.app.blueprint_name is None:
             print "Usage: nepho stack show-template <cloudlet> <blueprint>"
@@ -78,11 +78,7 @@ class NephoStackController(base.NephoBaseController):
         else:
             scope.print_scope(self)
 
-        s = self._assemble_scenario()
-
-        output  = "-" * 80 + "\n"
-        output += s.template
-        pager(output)
+        print self._assemble_scenario().template
 
 
     @controller.expose(help='Create a stack from a blueprint', aliases=['deploy', 'up'])

--- a/nepho/cli/stack.py
+++ b/nepho/cli/stack.py
@@ -77,8 +77,15 @@ class NephoStackController(base.NephoBaseController):
             exit(1)
         else:
             scope.print_scope(self)
+        
+        s = self._assemble_scenario()
 
-        print self._assemble_scenario().template
+        template_str = self._assemble_scenario().template
+        try:
+            template_str = s.provider.format_template(template_str)
+        except Exception as e: pass
+
+        print template_str
 
     @controller.expose(help='Create a stack from a blueprint', aliases=['deploy', 'up'])
     def create(self):

--- a/nepho/cli/stack.py
+++ b/nepho/cli/stack.py
@@ -63,11 +63,27 @@ class NephoStackController(base.NephoBaseController):
             scope.print_scope(self)
 
         s = self._assemble_scenario()
+
         output  = "-" * 80 + "\n"
         output += s.provider.validate_template(s.template)
         output += "\n" + "-" * 80 + "\n"
         output += s.template
         pager(output)
+
+    @controller.expose(help='Display the raw template output for a stack from a blueprint')
+    def show_template(self):
+        if self.app.cloudlet_name is None or self.app.blueprint_name is None:
+            print "Usage: nepho stack show-template <cloudlet> <blueprint>"
+            exit(1)
+        else:
+            scope.print_scope(self)
+
+        s = self._assemble_scenario()
+
+        output  = "-" * 80 + "\n"
+        output += s.template
+        pager(output)
+
 
     @controller.expose(help='Create a stack from a blueprint', aliases=['deploy', 'up'])
     def create(self):

--- a/nepho/providers/aws_provider.py
+++ b/nepho/providers/aws_provider.py
@@ -73,6 +73,16 @@ class AWSProvider(nepho.core.provider.AbstractProvider):
         return self._s3_conn
 
     def validate_template(self, template_str):
+
+        # Attempt to validate that template is valid JSON, and clean it up
+        try:
+            template_dict = json.loads(template_str)
+            template_str = json.dumps(template_dict, indent=2, separators=(',', ': '))
+        except Exception as e:
+            ret = "Validation:\n  Template JSON is not valid!\n"
+            ret += "Error:\n  %s\n" % (e)
+        return ret
+
         try:
             t = self.connection.validate_template(template_body=template_str)
 

--- a/nepho/providers/aws_provider.py
+++ b/nepho/providers/aws_provider.py
@@ -84,15 +84,16 @@ class AWSProvider(nepho.core.provider.AbstractProvider):
             return ret
 
         try:
-            t = self.connection.validate_template(template_body=template_str)
+            compact_template = json.dumps(json.loads(template_str), separators=(',',':'))
+            t = self.connection.validate_template(template_body=compact_template)
 
             ret = "Validation:\n  Template is valid\n"
             ret += "Description:\n %s\n" % t.description
             ret += "Parameters:"
             for p in t.template_parameters:
                 ret += "\n  %s" % (p.parameter_key)
-        except Exception as e:
-            ret = "Validation:\n  Template is not valid!\n"
+        except boto.exception.BotoServerError as e:
+            ret = "Boto Server Error:\n  Template is not valid!\n"
             ret += "Error:\n  %s\n" % (e.error_code)
             ret += "Description:\n  %s" % (e.body)
         return ret
@@ -158,10 +159,13 @@ class AWSProvider(nepho.core.provider.AbstractProvider):
             shutil.rmtree(tmp_dir)
 
         try:
+            # Use minimal size representation of this JSON string
+            compact_template_json = json.dumps(json.loads(template_json), separators=(',',':'))
+
             print "The Nepho elves are now building your stack. This may take a few minutes."
             stack_id = self.connection.create_stack(
                 stack_name,
-                template_body = template_json,
+                template_body = compact_template_json,
                 parameters = params,
                 capabilities = ['CAPABILITY_IAM'],
                 disable_rollback = True

--- a/nepho/providers/aws_provider.py
+++ b/nepho/providers/aws_provider.py
@@ -77,11 +77,11 @@ class AWSProvider(nepho.core.provider.AbstractProvider):
         # Attempt to validate that template is valid JSON, and clean it up
         try:
             template_dict = json.loads(template_str)
-            template_str = json.dumps(template_dict, indent=2, separators=(',', ': '))
+            template_str  = json.dumps(template_dict, indent=2, separators=(',', ': '))
         except Exception as e:
             ret = "Validation:\n  Template JSON is not valid!\n"
             ret += "Error:\n  %s\n" % (e)
-        return ret
+            return ret
 
         try:
             t = self.connection.validate_template(template_body=template_str)


### PR DESCRIPTION
Compact the JSON to accommodate larger templates, add a "show-template" function that doesn't try to validate so we can dump the template to a file, and pretty-print templates more when able.
